### PR TITLE
fix: upgrade torch to 2.6.0 for flash-attn 2.6.3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ tensorflow-datasets==4.9.3
 tensorflow-graphics==2021.12.3
 tensorflow-io==0.37.1
 tokenizers==0.21.0
-torch==2.5.1
-torchaudio==2.5.1
-torchvision==0.20.1
+torch==2.6.0
+torchaudio==2.6.0
+torchvision==0.21.0
 tqdm==4.66.6
 transformers==4.47.0
 triton==3.1.0


### PR DESCRIPTION
flash-attn 2.6.3 requires torch >= 2.6 for pre-built wheel compatibility. This upgrades torch from 2.5.1 to 2.6.0, with matching torchvision (0.21.0) and torchaudio (2.6.0) versions.

Closes #76